### PR TITLE
member() to check for namedMembers length

### DIFF
--- a/packages/import-sort/src/style/StyleAPI.ts
+++ b/packages/import-sort/src/style/StyleAPI.ts
@@ -36,11 +36,11 @@ function member(
     const first =
       firstImport.defaultMember ||
       firstImport.namespaceMember ||
-      firstImport.namedMembers[0].alias;
+      firstImport.namedMembers.length > 0 && firstImport.namedMembers[0].alias;
     const second =
       secondImport.defaultMember ||
       secondImport.namespaceMember ||
-      secondImport.namedMembers[0].alias;
+      secondImport.namedMembers.length > 0 && secondImport.namedMembers[0].alias;
 
     return comparator(first, second);
   };


### PR DESCRIPTION
Run into a problem having an import like 

```
import 'nprogress/nprogress.css';
```

and sorting rule like
```
            sort: member(unicode),
```
Import object will look like:
```
{
  start: 340,
  end: 372,
  importStart: 340,
  importEnd: 372,
  type: 'import',
  moduleName: 'nprogress/nprogress.css',
  namedMembers: []
}
```
and sorting will throw.